### PR TITLE
Fix function call, add consumer proguard rules

### DIFF
--- a/app/src/main/java/ca/psiphon/psicash/MainActivity.java
+++ b/app/src/main/java/ca/psiphon/psicash/MainActivity.java
@@ -25,7 +25,7 @@ public class MainActivity extends AppCompatActivity {
         tv.setText("Initial text");
 
         psiCashLib = new PsiCashLib();
-        PsiCashLib.Error err = psiCashLib.init(getFilesDir().toString(), new PsiCashLibHelper());
+        PsiCashLib.Error err = psiCashLib.init(getFilesDir().toString(), new PsiCashLibHelper(), false);
         if (err != null) {
             Log.e("PsiCashApp", err.message);
             return;

--- a/psicashlib/build.gradle
+++ b/psicashlib/build.gradle
@@ -22,6 +22,7 @@ android {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'consumer-proguard-rules.pro'
 
             externalNativeBuild {
                 cmake {

--- a/psicashlib/consumer-proguard-rules.pro
+++ b/psicashlib/consumer-proguard-rules.pro
@@ -1,0 +1,1 @@
+-keep class ca.psiphon.psicashlib.** {*;}


### PR DESCRIPTION
- Provide a minification rule to keep `ca.psiphon.psicashlib` package classes to library consumers.